### PR TITLE
Oprava stahování nepřečtených zpráv z IMAP

### DIFF
--- a/imap.php
+++ b/imap.php
@@ -40,9 +40,12 @@ class imap {
     
     public function emailsToParse(){
         $imap = $this->imapOpen();
-        $numMessages = imap_num_msg($imap);
-        $unreaded = imap_status($imap, $this->server, SA_UNSEEN);
-        for($i = $numMessages; $i > ($numMessages - $unreaded->unseen); $i--){
+        $messages = imap_search($imap, 'UNSEEN');
+        if (!$messages) {
+            return array();
+        }
+
+        foreach ($messages as $i) {
             imap_setflag_full($imap, $i, "\\Seen", ST_UID);
             $uid = imap_uid($imap, $i);
             $header = imap_header($imap, $i);


### PR DESCRIPTION
Pokud mailbox obsahuje mix přečtených a nepřečtených zpráv v náhodném pořadí, nefungovalo stahování zpráv korektně. PR toto chování opravuje použitím `imap_search` k získání nepřečtených zpráv.